### PR TITLE
Added switch to mark as requesting mentor and toast on send success

### DIFF
--- a/apps/web/app/(authenticated)/mentorship/find-mentorship/data-table.tsx
+++ b/apps/web/app/(authenticated)/mentorship/find-mentorship/data-table.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 
+import { useToast } from "@repo/ui/hooks/use-toast"
+import { Switch } from "@repo/ui/components/ui/switch"
 import { Button } from "@repo/ui/components/ui/button"
 import {
   ColumnDef,
@@ -36,10 +38,13 @@ export function DataTable<TData, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
   })
 
+  const { toast } = useToast()
+
   // States for connection modal
   const [selectedRow, setSelectedRow] = useState<TData | null>(null)
   const [optionalMessage, setOptionalMessage] = useState("")
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [requestMentorship, setRequestMentorship] = useState(true)
 
   const handleSubmitConnect = () => {
     // Integrate your connection request logic / API call here.
@@ -49,6 +54,12 @@ export function DataTable<TData, TValue>({
       "with message:",
       optionalMessage
     )
+    // Show success toast
+    toast({
+      description: "Connection request sent!",
+      duration: 3000,
+      className: "bg-green-50 border-green-200 text-green-600",
+    })
     // Reset state after submission.
     setOptionalMessage("")
     setIsModalOpen(false)
@@ -160,13 +171,22 @@ export function DataTable<TData, TValue>({
               value={optionalMessage}
               onChange={(e) => setOptionalMessage(e.target.value)}
             />
-            <div className="flex justify-end gap-2">
-              <Button variant="outline" onClick={handleCancelConnect}>
-                Cancel
-              </Button>
-              <Button variant="default" onClick={handleSubmitConnect}>
-                Submit
-              </Button>
+            <div className="flex justify-between items-center gap-2">
+              <div className="flex items-center space-x-2">
+                <Switch
+                  checked={requestMentorship}
+                  onCheckedChange={setRequestMentorship}
+                />
+                <span className="text-sm">Request mentorship</span>
+              </div>
+              <div className="flex gap-2">
+                <Button variant="outline" onClick={handleCancelConnect}>
+                  Cancel
+                </Button>
+                <Button variant="default" onClick={handleSubmitConnect}>
+                  Send
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3905,6 +3905,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.3.tgz",
+      "integrity": "sha512-1nc+vjEOQkJVsJtWPSiISGT6OKm4SiOdjMo+/icLxo2G4vxz1GntC5MzfL4v8ey9OEfw787QCD1y3mUv0NiFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.3.tgz",
@@ -18220,6 +18249,7 @@
         "@radix-ui/react-radio-group": "^1.2.2",
         "@radix-ui/react-select": "^2.1.5",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-switch": "^1.1.3",
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.5",
         "class-variance-authority": "^0.7.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-radio-group": "^1.2.2",
     "@radix-ui/react-select": "^2.1.5",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.5",
     "class-variance-authority": "^0.7.0",

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }


### PR DESCRIPTION
- Added a switch for "Request mentorship" that is toggleable. Is toggled true by default
- Toast appears on successful send of message

<img width="563" alt="image" src="https://github.com/user-attachments/assets/375c86e0-8e5e-495a-8109-15335a82201f" />
<img width="524" alt="image" src="https://github.com/user-attachments/assets/86ea7027-4fac-4275-a44a-bf741282eedb" />
